### PR TITLE
Allow use of delay-based GTFS-RT updates with stop_times.txt

### DIFF
--- a/custom_components/gtfs_realtime/coordinator.py
+++ b/custom_components/gtfs_realtime/coordinator.py
@@ -64,6 +64,7 @@ class GtfsRealtimeCoordinator(DataUpdateCoordinator):
         self.kwargs = kwargs
         self.gtfs_provider = gtfs_provider
         self.hub: FeedSubject = feed_subject
+        self.hub.max_api_calls_per_second = 1  # rate limit
         self.gtfs_update_data = GtfsUpdateData()
         self.gtfs_static_zip: Iterable[os.PathLike] | os.PathLike = gtfs_static_zip
         self.route_icons = route_icons

--- a/custom_components/gtfs_realtime/manifest.json
+++ b/custom_components/gtfs_realtime/manifest.json
@@ -11,7 +11,7 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/bcpearce/homeassistant-gtfs-realtime/issues",
   "requirements": [
-    "gtfs_station_stop==0.9.6"
+    "gtfs_station_stop==0.10.0"
   ],
-  "version": "0.2.12"
+  "version": "0.2.13"
 }

--- a/custom_components/gtfs_realtime/sensor.py
+++ b/custom_components/gtfs_realtime/sensor.py
@@ -1,6 +1,7 @@
 """Platform for sensor integration."""
 
 from __future__ import annotations
+import logging
 
 from gtfs_station_stop.arrival import Arrival
 from gtfs_station_stop.route_info import RouteType
@@ -39,6 +40,8 @@ from .coordinator import GtfsRealtimeCoordinator
 PLATFORM_SCHEMA = SENSOR_PLATFORM_SCHEMA.extend(
     {vol.Required(STOP_ID): cv.string, vol.Optional(CONF_ARRIVAL_LIMIT, default=4): int}
 )
+
+_LOGGER = logging.getLogger(__name__)
 
 
 async def async_setup_entry(
@@ -150,7 +153,10 @@ class ArrivalSensor(SensorEntity, CoordinatorEntity):
 
     def update(self) -> None:
         """Update state from coordinator data."""
-        time_to_arrivals = sorted(self.station_stop.get_time_to_arrivals())
+        stop_times_ds = self.coordinator.gtfs_update_data.schedule.stop_times_ds
+        time_to_arrivals = sorted(
+            self.station_stop.get_time_to_arrivals(stop_times_dataset=stop_times_ds)
+        )
         self._arrival_detail = {}
         if len(time_to_arrivals) > self._idx:
             schedule = self.coordinator.data.schedule
@@ -188,5 +194,13 @@ class ArrivalSensor(SensorEntity, CoordinatorEntity):
     @callback
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordainator."""
-        self.update()
-        super()._handle_coordinator_update()
+        try:
+            self.update()
+            super()._handle_coordinator_update()
+        except:
+            _LOGGER.error(
+                "Exception occurred updating %s provided by %s",
+                self.name,
+                self.coordinator.gtfs_provider,
+            )
+            raise

--- a/hooks/check_feed_compatibility.py
+++ b/hooks/check_feed_compatibility.py
@@ -26,190 +26,189 @@ STATUS_DICT = {
 
 URL_PARAM_PLACEHOLDERS = ["[ApiKey]"]
 
+if __name__ == "__main__":
 
-def _repr_without_query(e: ClientResponseError) -> str:
-    """Similar to str(e), but without query string which may contain sensitive params."""
-    url = e.request_info.url.with_query(None)
-    return f"{e.status}, message={e.message}, {url} (query may be hidden)"
+    def _repr_without_query(e: ClientResponseError) -> str:
+        """Similar to str(e), but without query string which may contain sensitive params."""
+        url = e.request_info.url.with_query(None)
+        return f"{e.status}, message={e.message}, {url} (query may be hidden)"
 
+    def _replace_placeholders(s: str) -> str:
+        """Replace user-friendly placeholders in feeds.json with a python-formattable brace."""
+        tmp = s
+        for i, ph in enumerate(URL_PARAM_PLACEHOLDERS):
+            tmp = tmp.replace(ph, f"{{{i}}}")
+        return tmp
 
-def _replace_placeholders(s: str) -> str:
-    """Replace user-friendly placeholders in feeds.json with a python-formattable brace."""
-    tmp = s
-    for i, ph in enumerate(URL_PARAM_PLACEHOLDERS):
-        tmp = tmp.replace(ph, f"{{{i}}}")
-    return tmp
-
-
-async def async_test_feed(
-    feed_id: str,
-    feed: dict[str, list[str]],
-    headers: dict[str, str] | None,
-    params: list[str] | None,
-) -> tuple[str, str]:
-    """Test a single feed."""
-    if params is None:
-        params = []
-    status = "Failed"
-    notice = ""
-    try:
-        for realtime in feed["realtime_feeds"].values():
-            rt = _replace_placeholders(realtime)
-            subject = FeedSubject([rt.format(*params)], headers=headers)
-            await subject.async_update()
-        for static in feed["static_feeds"].values():
-            st = _replace_placeholders(static)
-            await async_build_schedule(st.format(*params), headers=headers)
-        status = "Success"
-        if headers:
-            notice = "Auth Provided"
-    except* ClientResponseError as eg:
-        status_codes = [e.status for e in eg.exceptions]
-        notice = ",".join(f"{e.status}: {e.message}" for e in eg.exceptions)
+    async def async_test_feed(
+        feed_id: str,
+        feed: dict[str, list[str]],
+        headers: dict[str, str] | None,
+        params: list[str] | None,
+    ) -> tuple[str, str]:
+        """Test a single feed."""
+        if params is None:
+            params = []
         status = "Failed"
-        if any(sc in status_codes for sc in [401, 403]):
-            print(
-                f"Failed to authenticate the {feed_id} feed, an authentication header may be required",
-                file=sys.stderr,
-            )
-            for e in eg.exceptions:
-                print(f" * {_repr_without_query(e)}", file=sys.stderr)
-            if bool(headers):
+        notice = ""
+        try:
+            for realtime in feed["realtime_feeds"].values():
+                rt = _replace_placeholders(realtime)
+                subject = FeedSubject([rt.format(*params)], headers=headers)
+                await subject.async_update()
+            for static in feed["static_feeds"].values():
+                st = _replace_placeholders(static)
+                await async_build_schedule(st.format(*params), headers=headers)
+            status = "Success"
+            if headers:
+                notice = "Auth Provided"
+        except* ClientResponseError as eg:
+            status_codes = [e.status for e in eg.exceptions]
+            notice = ",".join(f"{e.status}: {e.message}" for e in eg.exceptions)
+            status = "Failed"
+            if any(sc in status_codes for sc in [401, 403]):
                 print(
-                    " * Headers were provided, check the credentials and retry",
+                    f"Failed to authenticate the {feed_id} feed, an authentication header may be required",
                     file=sys.stderr,
                 )
-        elif 429 in status_codes:
-            notice = "API Limit Exceeded"
-            status = "Unsure"
-        else:
+                for e in eg.exceptions:
+                    print(f" * {_repr_without_query(e)}", file=sys.stderr)
+                if bool(headers):
+                    print(
+                        " * Headers were provided, check the credentials and retry",
+                        file=sys.stderr,
+                    )
+            elif 429 in status_codes:
+                notice = "API Limit Exceeded"
+                status = "Unsure"
+            else:
+                print(
+                    f"Exceptions occurred processing feed {feed_id}: ", file=sys.stderr
+                )
+                for e in eg.exceptions:
+                    print(
+                        f" * {_repr_without_query(e)}",
+                        file=sys.stderr,
+                    )
+        except* IndexError:
+            print(f"Index error, {feed_id} requires a URL param that was not provided")
+            notice = "Missing URL parameter"
+        except* Exception as eg:
+            # fallthrough is failed
             print(f"Exceptions occurred processing feed {feed_id}: ", file=sys.stderr)
             for e in eg.exceptions:
-                print(
-                    f" * {_repr_without_query(e)}",
-                    file=sys.stderr,
-                )
-    except* IndexError:
-        print(f"Index error, {feed_id} requires a URL param that was not provided")
-        notice = "Missing URL parameter"
-    except* Exception as eg:
-        # fallthrough is failed
-        print(f"Exceptions occurred processing feed {feed_id}: ", file=sys.stderr)
-        for e in eg.exceptions:
-            print(f" * {e}", file=sys.stderr)
-    return status, notice
+                print(f" * {e}", file=sys.stderr)
+        return status, notice
 
-
-async def test_feeds(
-    feeds: dict[str, list[str]],
-    output_format: str = "dict",
-    headers_map: dict[str, dict[str, str]] | None = None,
-    params_map: dict[str, list[str]] | None = None,
-    *,
-    sleep_rate_limit: float = 0.0,
-) -> dict[str, str]:
-    """Test several feeds and report the valid ones."""
-    if output_format not in REPORT_FORMATS:
-        raise ValueError(
-            f"Report type {output_format} is not one of the allowed types in {REPORT_FORMATS}"
-        )
-    headers_map |= {}
-    params_map |= {}
-    results = {}
-    meter = tqdm.tqdm(feeds.items())
-    for feed_id, feed in meter:
-        meter.set_description(f"Verifying {feed['name']}")
-        header_key = ""
-        for key in headers_map.keys():
-            if re.search(key, feed_id):
-                header_key = key  # only match the first
-                break
-        params_key = ""
-        for key in params_map.keys():
-            if re.search(key, feed_id):
-                params_key = key  # only match the first
-                break
-        await asyncio.sleep(sleep_rate_limit)
-        results[feed_id] = await async_test_feed(
-            feed_id, feed, headers_map.get(header_key), params_map.get(params_key)
-        )
-
-    if output_format == "dict":
-        pprint(results)
-    elif output_format == "md":
-        print("# Feed Compatibility")
-        print("")
-        print("| Feed ID | Name | Status | Details |")
-        print("| ------- | ---- | ------ | ------- |")
-        for feed_id, status in results.items():
-            print(
-                f"| {feed_id} | {feeds[feed_id]['name']} | {STATUS_DICT.get(status[0], '❔')} {status[0]} | {STATUS_DICT.get(status[1], '')} {status[1]} |"
+    async def test_feeds(
+        feeds: dict[str, list[str]],
+        output_format: str = "dict",
+        headers_map: dict[str, dict[str, str]] | None = None,
+        params_map: dict[str, list[str]] | None = None,
+        *,
+        sleep_rate_limit: float = 0.0,
+    ) -> dict[str, str]:
+        """Test several feeds and report the valid ones."""
+        if output_format not in REPORT_FORMATS:
+            raise ValueError(
+                f"Report type {output_format} is not one of the allowed types in {REPORT_FORMATS}"
+            )
+        headers_map |= {}
+        params_map |= {}
+        results = {}
+        meter = tqdm.tqdm(feeds.items())
+        for feed_id, feed in meter:
+            meter.set_description(f"Verifying {feed['name']}")
+            header_key = ""
+            for key in headers_map.keys():
+                if re.search(key, feed_id):
+                    header_key = key  # only match the first
+                    break
+            params_key = ""
+            for key in params_map.keys():
+                if re.search(key, feed_id):
+                    params_key = key  # only match the first
+                    break
+            await asyncio.sleep(sleep_rate_limit)
+            results[feed_id] = await async_test_feed(
+                feed_id, feed, headers_map.get(header_key), params_map.get(params_key)
             )
 
-    return results
+        if output_format == "dict":
+            pprint(results)
+        elif output_format == "md":
+            print("# Feed Compatibility")
+            print("")
+            print("| Feed ID | Name | Status | Details |")
+            print("| ------- | ---- | ------ | ------- |")
+            for feed_id, status in results.items():
+                print(
+                    f"| {feed_id} | {feeds[feed_id]['name']} | {STATUS_DICT.get(status[0], '❔')} {status[0]} | {STATUS_DICT.get(status[1], '')} {status[1]} |"
+                )
 
+        return results
 
-if __name__ == "__main__":
-    filePath = Path(sys.argv[1])
+    if __name__ == "__main__":
+        filePath = Path(sys.argv[1])
 
-    parser = argparse.ArgumentParser(
-        description="Tool for checking validity of the feeds"
-    )
-    parser.add_argument("input_file", help="Input feed file")
-    parser.add_argument(
-        "--output-format",
-        "-f",
-        help=f"Output format for reporting, {REPORT_FORMATS}",
-        default="dict",
-    )
-    parser.add_argument(
-        "--auth-header",
-        "-a",
-        metavar="KEY=VALUE",
-        nargs="*",
-        help="Additional headers to include when making feed requests, should be in the form of <feed_id_regex>='<header>'",
-        default=None,
-    )
-    parser.add_argument(
-        "--url-param",
-        "-u",
-        metavar="KEY=VALUE",
-        nargs="*",
-        help="""
-        URL parameters to include when making feed requests, should be in the form <feed_id_regex>='<parameter>'
-        The parameter will 
-        """,
-        default=None,
-    )
-    parser.add_argument(
-        "--sleep-rate-limit",
-        "-s",
-        help="Sleep time between queuing tasks to help stay under API limits",
-        type=float,
-        default=0.0,
-    )
-    args = parser.parse_args()
-
-    auth: dict[str, dict[str, str]] = {}
-    params: dict[str, list[str]] = {}
-    for feed_id_to_auth_header in args.auth_header or []:
-        feed_id, auth_header = feed_id_to_auth_header.split("=")
-        header_key, header_value = (x.strip() for x in auth_header.split(":"))
-        auth[feed_id] = {header_key: header_value}
-
-    for feed_id_to_url_param in args.url_param or []:
-        feed_id, url_param = feed_id_to_url_param.split("=")
-        params[feed_id] = [url_param.strip()]
-
-    with open(filePath, "rb") as json_f:
-        feeds = json.load(json_f)
-
-    asyncio.run(
-        test_feeds(
-            feeds,
-            args.output_format,
-            auth,
-            params,
-            sleep_rate_limit=args.sleep_rate_limit,
+        parser = argparse.ArgumentParser(
+            description="Tool for checking validity of the feeds"
         )
-    )
+        parser.add_argument("input_file", help="Input feed file")
+        parser.add_argument(
+            "--output-format",
+            "-f",
+            help=f"Output format for reporting, {REPORT_FORMATS}",
+            default="dict",
+        )
+        parser.add_argument(
+            "--auth-header",
+            "-a",
+            metavar="KEY=VALUE",
+            nargs="*",
+            help="Additional headers to include when making feed requests, should be in the form of <feed_id_regex>='<header>'",
+            default=None,
+        )
+        parser.add_argument(
+            "--url-param",
+            "-u",
+            metavar="KEY=VALUE",
+            nargs="*",
+            help="""
+            URL parameters to include when making feed requests, should be in the form <feed_id_regex>='<parameter>'
+            The parameter will 
+            """,
+            default=None,
+        )
+        parser.add_argument(
+            "--sleep-rate-limit",
+            "-s",
+            help="Sleep time between queuing tasks to help stay under API limits",
+            type=float,
+            default=0.0,
+        )
+        args = parser.parse_args()
+
+        auth: dict[str, dict[str, str]] = {}
+        params: dict[str, list[str]] = {}
+        for feed_id_to_auth_header in args.auth_header or []:
+            feed_id, auth_header = feed_id_to_auth_header.split("=")
+            header_key, header_value = (x.strip() for x in auth_header.split(":"))
+            auth[feed_id] = {header_key: header_value}
+
+        for feed_id_to_url_param in args.url_param or []:
+            feed_id, url_param = feed_id_to_url_param.split("=")
+            params[feed_id] = [url_param.strip()]
+
+        with open(filePath, "rb") as json_f:
+            feeds = json.load(json_f)
+
+        asyncio.run(
+            test_feeds(
+                feeds,
+                args.output_format,
+                auth,
+                params,
+                sleep_rate_limit=args.sleep_rate_limit,
+            )
+        )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,14 +4,14 @@ build-backend = "hatchling.build"
 
 [project]
 name = "homeassistant-gtfs-realtime"
-version = "0.2.12"
+version = "0.2.13"
 description = "HomeAssistant custom integration for GTFS Realtime data."
 authors = [{ name= "Benjamin Pearce", email = "gtfs@bcpearce.com" }]
 license = "MIT"
 readme = "README.md"
 requires-python = ">=3.13.2"
 dependencies = [
-    "gtfs-station-stop==0.9.6",
+    "gtfs-station-stop==0.10.0",
 ]
 
 [dependency-groups]
@@ -54,6 +54,9 @@ disallow_untyped_defs = true
 warn_return_any = true
 warn_unreachable = true
 
+[tool.uv.sources]
+#gtfs-station-stop = { git = "https://github.com/bcpearce/gtfs-station-stop", branch = "main" }
+#gtfs-station-stop = { path = "../gtfs-station-stop" }
 
 
 

--- a/tests/snapshots/test_diagnostics.ambr
+++ b/tests/snapshots/test_diagnostics.ambr
@@ -48,6 +48,10 @@
           'Stop': Stop: None, lat: None, long: None,
         }),
       }),
+      'stop_times_ds': dict({
+        'stop_times': dict({
+        }),
+      }),
       'trip_info_ds': dict({
         'trip_infos': dict({
           'Trip': Trip: Route to ,

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -115,18 +115,18 @@ async def test_update(
     def coordinator_update_side_effects():
         arrivals = {
             "101N": [
-                Arrival(make_ts(4), "A", ""),
-                Arrival(make_ts(6), "B", ""),
-                Arrival(make_ts(8), "C", ""),
+                Arrival(route="A", trip="", time=make_ts(4)),
+                Arrival(route="B", trip="", time=make_ts(6)),
+                Arrival(route="C", trip="", time=make_ts(8)),
             ],
             "102S": [
-                Arrival(make_ts(9), "X", ""),
-                Arrival(make_ts(13), "Y", ""),
-                Arrival(make_ts(17), "Z", ""),
+                Arrival(route="X", trip="", time=make_ts(9)),
+                Arrival(route="Y", trip="", time=make_ts(13)),
+                Arrival(route="Z", trip="", time=make_ts(17)),
             ],
         }
-        for id, stop in coordinator.gtfs_update_data.station_stops.items():
-            stop.arrivals = arrivals[id]
+        for stop_id, stop in coordinator.gtfs_update_data.station_stops.items():
+            stop.arrivals = arrivals[stop_id]
         update_counter.update_count += 1
         return
 

--- a/uv.lock
+++ b/uv.lock
@@ -877,7 +877,7 @@ sdist = { url = "https://files.pythonhosted.org/packages/3d/55/ed46db9267d261585
 
 [[package]]
 name = "gtfs-station-stop"
-version = "0.9.6"
+version = "0.10.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiofiles" },
@@ -889,9 +889,9 @@ dependencies = [
     { name = "requests" },
     { name = "requests-cache" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/be/fd/fecd0fe49f499d35874531a3335678c72d5795b215488c557df0fa286e21/gtfs_station_stop-0.9.6.tar.gz", hash = "sha256:453b72bac83cbc3716117fc6746fcd893c8c062e2bda88b95b0f85c1e4fd3e0a", size = 109837, upload-time = "2025-07-28T18:08:32.533Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9c/18/fdd2f68c3ba2a91dcfa6b22ac90fb30650bc82cab3e72378d4dd3de0ed60/gtfs_station_stop-0.10.0.tar.gz", hash = "sha256:c5297fb14cd0dd921555630baccd7273b3c96200164f47ed6a3583de055c1abd", size = 112924, upload-time = "2025-07-31T03:18:12.102Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9a/04/5bf77cfef40eb71f9cd0d54462f4cf7c1f902ca60ccfdccdc8769cb1abab/gtfs_station_stop-0.9.6-py3-none-any.whl", hash = "sha256:f5644095d0fae756f12db175c65ffd35122355536729d5dc463697a4fa3cd5ed", size = 18698, upload-time = "2025-07-28T18:08:31.256Z" },
+    { url = "https://files.pythonhosted.org/packages/64/5e/ed6fe2443f28fb6505345ec7baaab15198b33bbc48149c85931b11aebc11/gtfs_station_stop-0.10.0-py3-none-any.whl", hash = "sha256:ce7ad3b3c18d80751cb00d55334a3820811ae6adf718501d3c0b98c33c789372", size = 21842, upload-time = "2025-07-31T03:18:10.663Z" },
 ]
 
 [[package]]
@@ -1074,7 +1074,7 @@ wheels = [
 
 [[package]]
 name = "homeassistant-gtfs-realtime"
-version = "0.2.12"
+version = "0.2.13"
 source = { editable = "." }
 dependencies = [
     { name = "gtfs-station-stop" },
@@ -1089,7 +1089,7 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "gtfs-station-stop", specifier = "==0.9.6" }]
+requires-dist = [{ name = "gtfs-station-stop", specifier = "==0.10.0" }]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
Originally only allowed explicit arrival time updates, now can handle updates using a delay + scheduled stop time.  Example of this type of feed is EXO (Quebec/Montreal) see #28 

This is largely due to updates for [GTFS Station Stop](https://github.com/bcpearce/gtfs-station-stop/releases/tag/0.10.0)

https://gtfs.org/documentation/schedule/reference/#stop_timestxt

See conditionally required Delay or Time 

https://gtfs.org/documentation/realtime/reference/#message-stoptimeevent

Additionally fixes issue where reused foreign keys for `stop_id` and `route_id` can result in failed attempts to add arrivals to route alerts. Example feed Philadelphia / SEPTA

Closes #30 