### PR TITLE
Pooled sessions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -182,6 +182,7 @@ home-assistant_v2.db-shm
 home-assistant_v2.db-wal
 
 # Ignore Misc
+gtfs_static_cache/*
 *.old
 *.zip
 custom_components/gtfs_realtime/user_feeds.json

--- a/custom_components/gtfs_realtime/coordinator.py
+++ b/custom_components/gtfs_realtime/coordinator.py
@@ -13,6 +13,7 @@ from gtfs_station_stop.schedule import GtfsSchedule, async_build_schedule
 from gtfs_station_stop.station_stop import StationStop
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 from .const import CONF_STATIC_SOURCES_UPDATE_FREQUENCY_DEFAULT, DOMAIN
 
@@ -86,7 +87,7 @@ class GtfsRealtimeCoordinator(DataUpdateCoordinator):
             )
         }
         await self.async_update_static_data()
-        await self.hub.async_update()
+        await self.hub.async_update(async_get_clientsession(self.hass))
         return self.gtfs_update_data
 
     async def async_update_static_data(self, clear_old_data=False):
@@ -98,11 +99,11 @@ class GtfsRealtimeCoordinator(DataUpdateCoordinator):
 
         if self.gtfs_update_data.schedule == GtfsSchedule():
             self.gtfs_update_data.schedule = await async_build_schedule(
-                *self.static_update_targets, **self.kwargs
+                *self.static_update_targets, session=None, **self.kwargs
             )
         else:
             await self.gtfs_update_data.schedule.async_update_schedule(
-                *self.static_update_targets, **self.kwargs
+                *self.static_update_targets, session=None, **self.kwargs
             )
 
         for target in self.static_update_targets:

--- a/custom_components/gtfs_realtime/sensor.py
+++ b/custom_components/gtfs_realtime/sensor.py
@@ -164,7 +164,9 @@ class ArrivalSensor(SensorEntity, CoordinatorEntity):
             time_to_arrival: Arrival = time_to_arrivals[self._idx]
 
             # Do not allow negative numbers
-            self._attr_native_value = max(time_to_arrival.time, 0)
+            self._attr_native_value = time_to_arrival.time and max(
+                time_to_arrival.time, 0
+            )
 
             # It's possible the route ID is empty, in that case, get it from the trips database
             # The remaining attributes will be filled below

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ warn_return_any = true
 warn_unreachable = true
 
 [tool.uv.sources]
-gtfs-station-stop = { git = "https://github.com/bcpearce/gtfs-station-stop", branch = "pooled-sessions" }
+#gtfs-station-stop = { git = "https://github.com/bcpearce/gtfs-station-stop", branch = "pooled-sessions" }
 #gtfs-station-stop = { path = "../gtfs-station-stop" }
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ license = "MIT"
 readme = "README.md"
 requires-python = ">=3.13.2"
 dependencies = [
-    "gtfs-station-stop==0.10.1",
+    "gtfs-station-stop==0.10.2",
 ]
 
 [dependency-groups]
@@ -55,7 +55,7 @@ warn_return_any = true
 warn_unreachable = true
 
 [tool.uv.sources]
-#gtfs-station-stop = { git = "https://github.com/bcpearce/gtfs-station-stop", branch = "main" }
+gtfs-station-stop = { git = "https://github.com/bcpearce/gtfs-station-stop", branch = "pooled-sessions" }
 #gtfs-station-stop = { path = "../gtfs-station-stop" }
 
 

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -112,7 +112,7 @@ async def test_update(
             start_time + timedelta(minutes=minutes - update_counter.update_count)
         ).timestamp()
 
-    def coordinator_update_side_effects():
+    def coordinator_update_side_effects(_):
         arrivals = {
             "101N": [
                 Arrival(route="A", trip="", time=make_ts(4)),

--- a/uv.lock
+++ b/uv.lock
@@ -279,6 +279,15 @@ wheels = [
 ]
 
 [[package]]
+name = "asyncio-atexit"
+version = "1.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/d3/dd2974be3f67c7ec96e0d6ab454429d0372cb7c7bffa3d0ac67a483cb801/asyncio-atexit-1.0.1.tar.gz", hash = "sha256:1d0c71544b8ee2c484d322844ee72c0875dde6f250c0ed5b6993592ab9f7d436", size = 4373, upload-time = "2022-04-26T08:54:16.998Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/65/10/d6abaefa57a52646651fd0383c056280b0853c0106229ece6bb38cd14463/asyncio_atexit-1.0.1-py3-none-any.whl", hash = "sha256:d93d5f7d5633a534abd521ce2896ed0fbe8de170bb1e65ec871d1c20eac9d376", size = 3752, upload-time = "2022-04-26T08:54:15.726Z" },
+]
+
+[[package]]
 name = "atomicwrites-homeassistant"
 version = "1.4.1"
 source = { registry = "https://pypi.org/simple" }
@@ -877,21 +886,18 @@ sdist = { url = "https://files.pythonhosted.org/packages/3d/55/ed46db9267d261585
 
 [[package]]
 name = "gtfs-station-stop"
-version = "0.10.1"
-source = { registry = "https://pypi.org/simple" }
+version = "0.10.2"
+source = { git = "https://github.com/bcpearce/gtfs-station-stop?branch=pooled-sessions#4fd039f44622d7d25f0221e97e5003508f8e9ef1" }
 dependencies = [
     { name = "aiofiles" },
     { name = "aiohttp" },
     { name = "aiohttp-client-cache", extra = ["sqlite"] },
+    { name = "asyncio-atexit" },
     { name = "coverage-badge" },
     { name = "gtfs-realtime-bindings" },
     { name = "protobuf" },
     { name = "requests" },
     { name = "requests-cache" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/92/1f/0415dca608d1e56b6582032ba6ffef6bcfd7a34381e39c04e1e4aa82a24a/gtfs_station_stop-0.10.1.tar.gz", hash = "sha256:69d3a2521bf497581c214f98489217cf76dc14c23cfddbd83261bee36fc55c72", size = 112939, upload-time = "2025-07-31T04:08:25.998Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ae/6a/d62fac4983c55b91828a1e523309d3adeb6bfb9be12839ad9e5f05f95ec5/gtfs_station_stop-0.10.1-py3-none-any.whl", hash = "sha256:4171a8a6a579c8071311affdc49cecb1b613fc43e7ac6bd1acdcbf4e3581ff7c", size = 21860, upload-time = "2025-07-31T04:08:24.305Z" },
 ]
 
 [[package]]
@@ -1089,7 +1095,7 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "gtfs-station-stop", specifier = "==0.10.1" }]
+requires-dist = [{ name = "gtfs-station-stop", git = "https://github.com/bcpearce/gtfs-station-stop?branch=pooled-sessions" }]
 
 [package.metadata.requires-dev]
 dev = [

--- a/uv.lock
+++ b/uv.lock
@@ -887,7 +887,7 @@ sdist = { url = "https://files.pythonhosted.org/packages/3d/55/ed46db9267d261585
 [[package]]
 name = "gtfs-station-stop"
 version = "0.10.2"
-source = { git = "https://github.com/bcpearce/gtfs-station-stop?branch=pooled-sessions#4fd039f44622d7d25f0221e97e5003508f8e9ef1" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiofiles" },
     { name = "aiohttp" },
@@ -898,6 +898,10 @@ dependencies = [
     { name = "protobuf" },
     { name = "requests" },
     { name = "requests-cache" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/15/41033cc7d3ab0ac9cdeb32f83bfde5aefc3ec81ee68a173f1d3f2c539a06/gtfs_station_stop-0.10.2.tar.gz", hash = "sha256:7a0335c48a823e7ba8d917b9d6fd9ae38cca14fd23ca13ffd3c637bb0e379dad", size = 113723, upload-time = "2025-08-01T03:30:25.755Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6a/42/46dc84c47df3f4e134df8b65588c2170777575262d91da14ea02f5c349cf/gtfs_station_stop-0.10.2-py3-none-any.whl", hash = "sha256:73704b938235c91acf30eebd7752dc45b6d7687122d30be731c36a0f0c9b06b4", size = 22444, upload-time = "2025-08-01T03:30:24.344Z" },
 ]
 
 [[package]]
@@ -1095,7 +1099,7 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "gtfs-station-stop", git = "https://github.com/bcpearce/gtfs-station-stop?branch=pooled-sessions" }]
+requires-dist = [{ name = "gtfs-station-stop", specifier = "==0.10.2" }]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
Use polled aiohttp sessions (see equivalent in gtfs-station-stop). This reduces database contention on cached static zip files as well. 