### PR TITLE
Match alerts on uppercased language codes as well

### DIFF
--- a/custom_components/gtfs_realtime/binary_sensor.py
+++ b/custom_components/gtfs_realtime/binary_sensor.py
@@ -96,10 +96,10 @@ class AlertSensor(BinarySensorEntity, CoordinatorEntity):
             self._attr_is_on = True
             for i, alert in enumerate(alerts):
                 self._alert_detail[f"header_{i + 1}"] = alert.header_text.get(
-                    self.language, ""
+                    self.language, alert.header_text.get(self.language.upper(), "")
                 )
                 self._alert_detail[f"description_{i + 1}"] = alert.description_text.get(
-                    self.language, ""
+                    self.language, alert.header_text.get(self.language.upper(), "")
                 )
 
     @callback

--- a/custom_components/gtfs_realtime/manifest.json
+++ b/custom_components/gtfs_realtime/manifest.json
@@ -13,5 +13,5 @@
   "requirements": [
     "gtfs_station_stop==0.11.7"
   ],
-  "version": "0.4.5"
+  "version": "0.4.6"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ license = "MIT"
 name = "homeassistant-gtfs-realtime"
 readme = "README.md"
 requires-python = ">=3.13.2"
-version = "0.4.5"
+version = "0.4.6"
 
 [dependency-groups]
 dev = [

--- a/uv.lock
+++ b/uv.lock
@@ -1580,7 +1580,7 @@ wheels = [
 
 [[package]]
 name = "homeassistant-gtfs-realtime"
-version = "0.4.5"
+version = "0.4.6"
 source = { editable = "." }
 dependencies = [
     { name = "gtfs-station-stop" },


### PR DESCRIPTION
Adds a fallback to check uppercase language strings as well. It was noticed that NYC Bus Alerts report data using uppercase codes even though this is not compliant with ISO 639 .